### PR TITLE
Initial organization of files/etc.

### DIFF
--- a/react-native-expo/README.md
+++ b/react-native-expo/README.md
@@ -4,9 +4,9 @@
 
 The `react-native-expo` directory is aliased as `@` in `tsconfig.json`. When an import would require traversing more than one parent directory, use the `@` alias instead:
 
-- `import Button from '../system/components/Button'` ✅
-- `import Button from '../../system/components/Button'` ❌
-- `import Button from '@/system/components/Button'` ✅
+- `import Button from '../components/Button'` ✅
+- `import Button from '../../components/Button'` ❌
+- `import Button from '@/components/Button'` ✅
 
 Note: this only works in TypeScript (`.ts`/`.tsx`) files.
 

--- a/react-native-expo/README.md
+++ b/react-native-expo/README.md
@@ -1,0 +1,139 @@
+# Expo app
+
+## File organization
+
+The `react-native-expo` directory is aliased as `@` in `tsconfig.json`. When an import would require traversing more than one parent directory, use the `@` alias instead:
+
+- `import Button from '../system/components/Button'` ✅
+- `import Button from '../../system/components/Button'` ❌
+- `import Button from '@/system/components/Button'` ✅
+
+Note: this only works in TypeScript (`.ts`/`.tsx`) files.
+
+### Directories
+
+Expo's [file-based routing](https://docs.expo.dev/develop/file-based-routing/) system uses the `app` directory for defining routes and layouts:
+
+> ...`app` is a special directory. Any file you add to this directory becomes a route inside the native app...
+>
+> Layout files in a directory are used to define shared UI elements such as headers, tab bars so that they persist between different routes.
+>
+> – [Expo docs](https://docs.expo.dev/develop/file-based-routing/)
+
+In this repo, we use the `app` directory _only_ for defining route components and their corresponding layout components. We don't include _any_ UI or business logic in these route or layout components — any UI that is rendered for a given route or logic MUST be imported from the `components` directory.
+
+Route components MUST be suffixed with `*Route`. So the home route component should be named `HomeRoute`.
+
+Components defining the UI for a screen MUST be suffixed with `*Screen`. So, the home screen component should be named `HomeScreen`. The `HomeRoute` component would import and render _only_ the `HomeScreen` component, and optionally pass it any routing props it needs.
+
+If a given route needs to define layout for it and its children, the `_layout.tsx` file will be placed next to the `index.tsx` file for a given route. The `_layout.tsx` file MUST have a single export — a `Layout` component that simply imports and renders a `*Layout` component from the `components` directory. For example, the home route's `_layout.tsx` file would export a `Layout` component that simply imports and renders the `HomeLayout` component from the `components` directory.
+
+In short: all UI lives under the `components` directory. All route components live under the `app` directory, and don't render any UI of their own.
+
+### Components
+
+- For single-file components, the filename MUST be `ComponentName.tsx`.
+- For multi-file components (e.g., components with test, Storybook, etc. files), the component MUST be located in a directory named for the component, and the component filename itself MUST be `index.tsx`, so that it can be imported with `import MyComponent from '@/components/MyComponent'`.
+  - For example, a `Foo` component with only a `Foo.tsx` file could live alongside other components in a single directory, but a `Bar` component with test and Storybook files must live in a `Bar` subdirectory:
+  ```
+  - src/components/
+    - Foo.tsx
+    - Bar/
+      - index.tsx
+      - index.test.tsx
+      - index.stories.ts
+  ```
+- All screen components (i.e., those ending with `Screen`) MUST be in the `/src/components/screens` directory.
+  - Children of screen components (i.e., components that only exist on that screen) MUST be located underneath that screen's component directory. For example, if a `<Header />` component only exists inside the `SinglePostScreen`, the files should be arranged as follows:
+  ```
+  - src/components/screens/
+    - SinglePostScreen/
+      - index.tsx
+      - Header/
+        - index.tsx
+        - index.test.tsx
+  ```
+- All navigator components (i.e., those ending with `Navigator`) MUST be in the `/src/components/navigators` directory.
+- Components that are only used within a parent component MUST sit in the parent component's directory, rather than be a sibling of the parent directory:
+  ```
+  - src/components/
+    - HeaderWithDropdown/
+      - index.tsx
+      - Dropdown.tsx ✅ Correct, if Dropdown is only ever used inside HeaderWithDropdown
+  ```
+  ```
+  - src/components/
+    - Dropdown.tsx ❌ Wrong, if Dropdown is only ever used inside HeaderWithDropdown
+    - HeaderWithDropdown/
+      - index.tsx
+  ```
+  (One exception to this rule: if you're developing a component that will eventually be used by multiple other components, and just happens to be a child of only a single component at the moment, you can leave it as a sibling of its parent.)
+- If a parent is the only parent of a given component, then it MUST live in an eponymous directory. For example, if a `HeaderWithDropdown` component has `Dropdown` as a child component, `HeaderWithDropdown` must live in its own `HeaderWithDropdown` directory, which also includes the `Dropdown` component:
+  ```
+  - src/components/
+    - HeaderWithDropdown/
+      - index.tsx
+      - Dropdown.tsx
+  ```
+  If `Dropdown` were to later have children of its own, `Dropdown` would move into a new `HeaderWithDropdown/Dropdown` subdirectory along with its children:
+  ```
+  - src/components/
+    - HeaderWithDropdown/
+      - index.tsx
+      - Dropdown/
+        - index.tsx
+        - DropdownItem.tsx
+  ```
+- Components should be located at the most specific possible directory level. For example, if the `Dropdown` component is used by both `HeaderWithDropdown` and `Menu` components, `Dropdown` should be placed in the lowest-level directory that contains both `HeaderWithDropdown` and `Menu`:
+
+  ```
+  - src/components/
+    - SomeCommonParentOfBothHeaderWithDropdownAndMenu/
+      - index.tsx
+      - HeaderWithDropdown/
+        - index.tsx
+        - index.test.tsx
+      - Menu/
+        - index.tsx
+        - index.test.tsx
+      - Dropdown.tsx ✅ Correct - Dropdown is used by both Menu and HeaderWithDropdown, so it's a sibling to both
+  ```
+
+  This, as opposed to e.g., placing it inside the `HeaderWithDropdown` directory (and then importing it from there in `Menu`), or inside a root-level directory. This way, components are nested as closely to the components using them as possible.
+
+  ```
+  - src/components/
+    - SomeCommonParentOfBothHeaderWithDropdownAndMenu/
+      - index.tsx
+      - HeaderWithDropdown/
+        - index.tsx
+        - index.test.tsx
+        - Dropdown.tsx ❌ Wrong - Menu shouldn't be importing a child of HeaderWithDropdown
+      - Menu/
+        - index.tsx
+        - index.test.tsx
+  ```
+
+- Components MUST be the default export of the file that contains them:
+
+  ```TypeScript
+  export default function Foo() {
+    // ...
+  }
+  ```
+
+  This allows components to be imported like so:
+
+  ```TypeScript
+  import Foo from '@/components/Foo'
+  ```
+
+- If there are multiple components in a file:
+  - There MUST NOT be more than one component _exported_ from the file. (If other components in the file need to be exported, move them into separate files.)
+  - The file MUST be named for the component which is exported, or be named `index.tsx` when it is in its own directory.
+
+## Naming conventions
+
+### Components
+
+Components MUST be named in UpperCamelCase: e.g., `DropdownMenu`.

--- a/react-native-expo/app/_layout.tsx
+++ b/react-native-expo/app/_layout.tsx
@@ -1,5 +1,5 @@
-import { Stack } from "expo-router";
+import RootLayout from '@/components/RootLayout';
 
-export default function RootLayout() {
-  return <Stack />;
+export default function Layout() {
+  return <RootLayout />;
 }

--- a/react-native-expo/app/index.tsx
+++ b/react-native-expo/app/index.tsx
@@ -3,7 +3,7 @@ import { getBlockHeight } from '@/modules/penumbra-sdk-module';
 import React, { useContext, useEffect, useState } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 
-export default function App() {
+export default function AppRoute() {
   const [counter, setCounter] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const appInitialization = useContext(AppInitializationContext);

--- a/react-native-expo/app/index.tsx
+++ b/react-native-expo/app/index.tsx
@@ -1,31 +1,16 @@
-import React, { useEffect, useState } from 'react';
-import { createAppStateContainer, getBlockHeight, startServer } from '@/modules/penumbra-sdk-module';
+import AppInitializationContext from '@/contexts/AppInitializationContext';
+import { getBlockHeight } from '@/modules/penumbra-sdk-module';
+import React, { useContext, useEffect, useState } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 
 export default function App() {
   const [counter, setCounter] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
-  // Handle initialization
-  useEffect(() => {
-    const initializeApp = async () => {
-      try {
-        await createAppStateContainer();
-        await startServer();
-        setIsLoading(false);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to initialize');
-        setIsLoading(false);
-      }
-    };
-
-    initializeApp();
-  }, []);
+  const appInitialization = useContext(AppInitializationContext);
 
   // Handle block height polling
   useEffect(() => {
-    if (isLoading) return;
+    if (appInitialization.isLoading) return;
 
     const interval = setInterval(async () => {
       try {
@@ -37,12 +22,12 @@ export default function App() {
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [isLoading]);
+  }, [appInitialization.isLoading]);
 
-  if (isLoading) {
+  if (appInitialization.isLoading) {
     return (
       <View style={styles.container}>
-        <ActivityIndicator size="large" color="#0000ff" />
+        <ActivityIndicator size='large' color='#0000ff' />
         <Text style={styles.text}>Initializing...</Text>
       </View>
     );

--- a/react-native-expo/components/RootLayout/index.tsx
+++ b/react-native-expo/components/RootLayout/index.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function RootLayout() {
+  return <Stack />;
+}

--- a/react-native-expo/components/RootLayout/index.tsx
+++ b/react-native-expo/components/RootLayout/index.tsx
@@ -1,5 +1,13 @@
+import AppInitializationContext from '@/contexts/AppInitializationContext';
 import { Stack } from 'expo-router';
+import useInitializeApp from './useInitializeApp';
 
 export default function RootLayout() {
-  return <Stack />;
+  const appInitialization = useInitializeApp();
+
+  return (
+    <AppInitializationContext.Provider value={appInitialization}>
+      <Stack />
+    </AppInitializationContext.Provider>
+  );
 }

--- a/react-native-expo/components/RootLayout/index.tsx
+++ b/react-native-expo/components/RootLayout/index.tsx
@@ -1,4 +1,6 @@
 import AppInitializationContext from '@/contexts/AppInitializationContext';
+import { DripsyProvider } from 'dripsy';
+import dripsyTheme from '@/utils/dripsyTheme';
 import { Stack } from 'expo-router';
 import useInitializeApp from './useInitializeApp';
 
@@ -6,8 +8,10 @@ export default function RootLayout() {
   const appInitialization = useInitializeApp();
 
   return (
-    <AppInitializationContext.Provider value={appInitialization}>
-      <Stack />
-    </AppInitializationContext.Provider>
+    <DripsyProvider theme={dripsyTheme}>
+      <AppInitializationContext.Provider value={appInitialization}>
+        <Stack />
+      </AppInitializationContext.Provider>
+    </DripsyProvider>
   );
 }

--- a/react-native-expo/components/RootLayout/useInitializeApp.ts
+++ b/react-native-expo/components/RootLayout/useInitializeApp.ts
@@ -1,0 +1,24 @@
+import { createAppStateContainer, startServer } from '@/modules/penumbra-sdk-module';
+import { useEffect, useState } from 'react';
+
+export default function useInitializeApp() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const initializeApp = async () => {
+      try {
+        await createAppStateContainer();
+        await startServer();
+        setIsLoading(false);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to initialize');
+        setIsLoading(false);
+      }
+    };
+
+    initializeApp();
+  }, []);
+
+  return { isLoading, error };
+}

--- a/react-native-expo/contexts/AppInitializationContext.ts
+++ b/react-native-expo/contexts/AppInitializationContext.ts
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+const AppInitializationContext = createContext<{ isLoading: boolean; error: string | null }>({
+  isLoading: false,
+  error: null,
+});
+export default AppInitializationContext;

--- a/react-native-expo/package.json
+++ b/react-native-expo/package.json
@@ -18,6 +18,7 @@
     "@expo/vector-icons": "^14.0.2",
     "@react-navigation/bottom-tabs": "^7.0.0",
     "@react-navigation/native": "^7.0.0",
+    "dripsy": "^4.3.8",
     "expo": "^52.0.17",
     "expo-blur": "~14.0.1",
     "expo-constants": "~17.0.3",

--- a/react-native-expo/utils/dripsyTheme.ts
+++ b/react-native-expo/utils/dripsyTheme.ts
@@ -1,0 +1,20 @@
+import { makeTheme } from 'dripsy';
+import { theme } from './theme';
+
+const dripsyTheme = makeTheme({
+  ...theme,
+  breakpoints: [
+    `${theme.breakpoint.mobile}px`,
+    `${theme.breakpoint.tablet}px`,
+    `${theme.breakpoint.desktop}px`,
+    `${theme.breakpoint.lg}px`,
+    `${theme.breakpoint.xl}px`,
+  ],
+});
+export default dripsyTheme;
+type DripsyTheme = typeof dripsyTheme;
+
+declare module 'dripsy' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface DripsyCustomTheme extends DripsyTheme {}
+}

--- a/react-native-expo/utils/dripsyTheme.ts
+++ b/react-native-expo/utils/dripsyTheme.ts
@@ -1,15 +1,11 @@
 import { makeTheme } from 'dripsy';
 import { theme } from './theme';
 
+const BREAKPOINTS: (keyof typeof theme.breakpoint)[] = ['mobile', 'tablet', 'desktop', 'lg', 'xl'];
+
 const dripsyTheme = makeTheme({
   ...theme,
-  breakpoints: [
-    `${theme.breakpoint.mobile}px`,
-    `${theme.breakpoint.tablet}px`,
-    `${theme.breakpoint.desktop}px`,
-    `${theme.breakpoint.lg}px`,
-    `${theme.breakpoint.xl}px`,
-  ],
+  breakpoints: BREAKPOINTS.map(breakpoint => `${theme.breakpoint[breakpoint]}px`),
 });
 export default dripsyTheme;
 type DripsyTheme = typeof dripsyTheme;

--- a/react-native-expo/utils/hexOpacity.ts
+++ b/react-native-expo/utils/hexOpacity.ts
@@ -1,0 +1,12 @@
+/**
+ * Given a decimal opacity (between 0 and 1), returns a two-character string
+ * that can be appended to an RGB value for the alpha channel.
+ *
+ * ```ts
+ * `#000000${opacityInHex(0.5)}` // #00000080 -- i.e., black at 50% opacity
+ * ```
+ */
+export const hexOpacity = (opacity: number) =>
+  Math.round(opacity * 255)
+    .toString(16)
+    .padStart(2, '0');

--- a/react-native-expo/utils/theme.ts
+++ b/react-native-expo/utils/theme.ts
@@ -1,0 +1,317 @@
+/**
+ * 🚨 DO NOT MODIFY THIS FILE!
+ *
+ * This file has _temporarily_ been copied over from `@penumbra-zone/ui`. Once
+ * that library exports this file on its own, we'll delete this file and import
+ * from there.
+ */
+import { hexOpacity } from './hexOpacity';
+
+/**
+ * Used for reference in the `theme` object below. Not intended to be used
+ * directly by consumers, but rather as a semantic reference for building the
+ * theme.
+ */
+const PALETTE = {
+  green: {
+    50: '#f0fdf4',
+    100: '#DEFAE8',
+    200: '#BFF3D1',
+    300: '#8DE8AE',
+    400: '#55D383',
+    500: '#2DBA61',
+    600: '#1F9A4C',
+    700: '#1C793F',
+    800: '#1C5F36',
+    900: '#194E2E',
+    950: '#03160B',
+  },
+  neutral: {
+    50: '#fafafa',
+    100: '#f5f5f5',
+    200: '#e5e5e5',
+    300: '#d4d4d4',
+    400: '#a3a3a3',
+    500: '#737373',
+    600: '#525252',
+    700: '#404040',
+    800: '#262626',
+    900: '#171717',
+    950: '#0a0a0a',
+  },
+  orange: {
+    50: '#FFF8ED',
+    100: '#FDEED6',
+    200: '#FBDBAD',
+    300: '#F8C079',
+    400: '#F49C43',
+    500: '#F07E1C',
+    600: '#E16615',
+    700: '#BA4D14',
+    800: '#933E19',
+    900: '#773517',
+    950: '#200B04',
+  },
+  purple: {
+    50: '#FAF7FC',
+    100: '#F5F0F7',
+    200: '#E9E0EE',
+    300: '#D8C7E0',
+    400: '#C1A6CC',
+    500: '#A582B3',
+    600: '#886693',
+    700: '#705279',
+    800: '#5F4766',
+    900: '#4F3C53',
+    950: '#180E1B',
+  },
+  red: {
+    50: '#fef2f2',
+    100: '#FCE4E4',
+    200: '#FBCDCD',
+    300: '#F8A9A9',
+    400: '#F17878',
+    500: '#E54E4E',
+    600: '#CF3333',
+    700: '#AF2626',
+    800: '#902424',
+    900: '#772525',
+    950: '#1E0606',
+  },
+  teal: {
+    50: '#f1fcfa',
+    100: '#D4F3EE',
+    200: '#92DFD5',
+    300: '#77D1C8',
+    400: '#53AEA8',
+    500: '#319B96',
+    600: '#257C79',
+    700: '#226362',
+    800: '#204F4F',
+    900: '#1F4242',
+    950: '#031516',
+  },
+  yellow: {
+    50: '#FDFCE9',
+    100: '#FBF7C6',
+    200: '#F8EB90',
+    300: '#F4DA50',
+    400: '#E8C127',
+    500: '#DDAD15',
+    600: '#C0860E',
+    700: '#99610F',
+    800: '#7E4D15',
+    900: '#6B3F18',
+    950: '#201004',
+  },
+  base: {
+    black: '#000000',
+    blackAlt: '#0D0D0D',
+    white: '#ffffff',
+    transparent: 'transparent',
+  },
+} as const;
+
+/**
+ * Call `theme.spacing(x)`, where `x` is the number of spacing units (in the
+ * Penumbra theme, 1 spacing unit = 4px) that you want to interpolate into your
+ * CSS or JavaScript. By default, returns a string with the number of pixels
+ * suffixed with `px` -- e.g., `theme.spacing(4)` returns `'16px'`. Pass
+ * `number` as the second argument to get back a number of pixels -- e.g.,
+ * `theme.spacing(4, 'number')` returns `16`.
+ */
+function spacing(spacingUnits: number, returnType?: 'string'): string;
+function spacing(spacingUnits: number, returnType: 'number'): number;
+function spacing(spacingUnits: number, returnType?: 'string' | 'number'): string | number {
+  if (returnType === 'number') {
+    return spacingUnits * 4;
+  }
+  return `${spacingUnits * 4}px`;
+}
+
+export const theme = {
+  blur: {
+    none: '0px',
+    xs: '4px',
+    sm: '8px',
+    md: '16px',
+    lg: '32px',
+    xl: '64px',
+  },
+  borderRadius: {
+    none: '0px',
+    xs: '4px',
+    sm: '8px',
+    md: '12px',
+    lg: '16px',
+    xl: '20px',
+    '2xl': '24px',
+    full: '9999px',
+  },
+  breakpoint: {
+    mobile: 0,
+    tablet: 600,
+    desktop: 900,
+    lg: 1200,
+    xl: 1600,
+  },
+  color: {
+    neutral: {
+      main: PALETTE.neutral['700'],
+      light: PALETTE.neutral['400'],
+      dark: PALETTE.neutral['900'],
+      contrast: PALETTE.neutral['50'],
+    },
+    primary: {
+      main: PALETTE.orange['700'],
+      light: PALETTE.orange['400'],
+      dark: PALETTE.orange['950'],
+      contrast: PALETTE.orange['50'],
+    },
+    secondary: {
+      main: PALETTE.teal['700'],
+      light: PALETTE.teal['400'],
+      dark: PALETTE.teal['950'],
+      contrast: PALETTE.teal['50'],
+    },
+    unshield: {
+      main: PALETTE.purple['700'],
+      light: PALETTE.purple['400'],
+      dark: PALETTE.purple['950'],
+      contrast: PALETTE.purple['50'],
+    },
+    destructive: {
+      main: PALETTE.red['700'],
+      light: PALETTE.red['400'],
+      dark: PALETTE.red['950'],
+      contrast: PALETTE.red['50'],
+    },
+    caution: {
+      main: PALETTE.yellow['700'],
+      light: PALETTE.yellow['400'],
+      dark: PALETTE.yellow['950'],
+      contrast: PALETTE.yellow['50'],
+    },
+    success: {
+      main: PALETTE.green['700'],
+      light: PALETTE.green['400'],
+      dark: PALETTE.green['950'],
+      contrast: PALETTE.green['50'],
+    },
+    base: {
+      black: PALETTE.base.black,
+      blackAlt: PALETTE.base.blackAlt,
+      white: PALETTE.base.white,
+      transparent: PALETTE.base.transparent,
+    },
+    text: {
+      primary: PALETTE.neutral['50'],
+      secondary: PALETTE.neutral['400'],
+      muted: PALETTE.neutral['700'],
+      special: PALETTE.orange['400'],
+    },
+    action: {
+      hoverOverlay: PALETTE.teal['400'] + hexOpacity(0.15),
+      activeOverlay: PALETTE.neutral['950'] + hexOpacity(0.15),
+      disabledOverlay: PALETTE.neutral['950'] + hexOpacity(0.8),
+      primaryFocusOutline: PALETTE.orange['400'],
+      secondaryFocusOutline: PALETTE.teal['400'],
+      unshieldFocusOutline: PALETTE.purple['400'],
+      neutralFocusOutline: PALETTE.neutral['400'],
+      destructiveFocusOutline: PALETTE.red['400'],
+      successFocusOutline: PALETTE.green['400'],
+    },
+    other: {
+      tonalStroke: PALETTE.neutral['50'] + hexOpacity(0.15),
+      tonalFill5: PALETTE.neutral['50'] + hexOpacity(0.05),
+      tonalFill10: PALETTE.neutral['50'] + hexOpacity(0.1),
+      solidStroke: PALETTE.neutral['900'],
+      dialogBackground: PALETTE.teal['700'] + hexOpacity(0.1),
+      overlay: PALETTE.base.black + hexOpacity(0.5),
+    },
+  },
+  gradient: {
+    card: 'linear-gradient(136deg, rgba(250, 250, 250, 0.1) 6.32%, rgba(250, 250, 250, 0.01) 75.55%)',
+    neutralRadialGradient:
+      'radial-gradient(50% 100% at 50% 100%, rgba(163, 163, 163, 0.35) 0%, rgba(163, 163, 163, 0.00) 95%)',
+    accentRadialGradient:
+      'radial-gradient(50% 100% at 50% 100%, rgba(186, 77, 20, 0.35) 0%, rgba(186, 77, 20, 0.00) 95%)',
+    unshieldRadialGradient:
+      'radial-gradient(50% 100% at 50% 100%, rgba(112, 82, 121, 0.35) 0%, rgba(112, 82, 121, 0.00) 95%)',
+    accentRadialBackground:
+      'radial-gradient(100% 100% at 0% 0%, rgba(244, 156, 67, 0.25) 0%, rgba(244, 156, 67, 0.03) 100%)',
+    unshieldRadialBackground:
+      'radial-gradient(100% 100% at 0% 0%, rgba(193, 166, 204, 0.25) 0%, rgba(193, 166, 204, 0.03) 100%)',
+    secondaryRadialBackground:
+      'radial-gradient(100% 100% at 0% 0%, rgba(83, 174, 168, 0.25) 0%, rgba(83, 174, 168, 0.03) 100%)',
+    cautionRadialBackground:
+      'radial-gradient(100% 100% at 0% 0%, rgba(153, 97, 15, 0.25) 0%, rgba(153, 97, 15, 0.03) 100%)',
+    destructiveRadialBackground:
+      'radial-gradient(100% 100% at 0% 0%, rgba(175, 38, 38, 0.25) 0%, rgba(175, 38, 38, 0.03) 100%)',
+    buttonHover:
+      'linear-gradient(0deg, rgba(83, 174, 168, 0.15) 0%, rgba(83, 174, 168, 0.15) 100%)',
+    buttonDisabled: 'linear-gradient(0deg, rgba(10, 10, 10, 0.8) 0%, rgba(10, 10, 10, 0.8) 100%)',
+    progressLoading:
+      'linear-gradient(90deg,rgba(255, 255, 255, 0) 0%,#fff 50%,rgba(255, 255, 255, 0) 100%)',
+  },
+  font: {
+    default: 'Poppins',
+    mono: 'Iosevka Term, monospace',
+    heading: 'Work Sans',
+  },
+  fontSize: {
+    text9xl: '8rem',
+    text8xl: '6rem',
+    text7xl: '4.5rem',
+    text6xl: '3.75rem',
+    text5xl: '3rem',
+    text4xl: '2.25rem',
+    text3xl: '1.875rem',
+    text2xl: '1.5rem',
+    textXl: '1.25rem',
+    textLg: '1.125rem',
+    textBase: '1rem',
+    textSm: '0.875rem',
+    textXs: '0.75rem',
+    textXxs: '0.6875rem',
+  },
+  lineHeight: {
+    text9xl: '8.25rem',
+    text8xl: '6.25rem',
+    text7xl: '5rem',
+    text6xl: '4.25rem',
+    text5xl: '3.5rem',
+    text4xl: '2.75rem',
+    text3xl: '2.5rem',
+    text2xl: '2.25rem',
+    textXl: '2rem',
+    textLg: '1.75rem',
+    textBase: '1.5rem',
+    textSm: '1.25rem',
+    textXs: '1rem',
+    textXxs: '1rem',
+  },
+  spacing,
+  zIndex: {
+    disabledOverlay: 10,
+  },
+  keyframes: {
+    scale: {
+      '0%': { opacity: '0', transform: 'scale(0)' },
+      '100%': { opacity: '1', transform: 'scale(1)' },
+    },
+    progress: {
+      '0%': { left: '-20%' },
+      '100%': { left: '100%' },
+    },
+  },
+  animation: {
+    scale: 'scale 0.15s ease-out',
+    progress: 'progress 1s linear infinite',
+  },
+} as const;
+
+type Theme = typeof theme;
+export type Color = keyof Theme['color'];
+export type ColorVariant = keyof Theme['color']['neutral'];
+export type TextColorVariant = keyof Theme['color']['text'];

--- a/react-native-expo/yarn.lock
+++ b/react-native-expo/yarn.lock
@@ -1043,6 +1043,11 @@
     resolve-from "^5.0.0"
     semver "^7.6.0"
 
+"@expo/html-elements@^0.2.0":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@expo/html-elements/-/html-elements-0.2.2.tgz#d4d361df6c4089d67cc2fd98d34a5347ac4c1a5d"
+  integrity sha512-hMS/5UfBgusKo5K0kpXdrddkxBg9LaJ8Dnijxats+7Uj0Mrk+NaRx3jOUsHTzd7pAroeqx5WGwzJ7wppsksBVA==
+
 "@expo/image-utils@^0.6.0":
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.6.3.tgz#89c744460beefc686989b969121357bbd5520c8a"
@@ -1863,6 +1868,13 @@
   integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
   dependencies:
     "@sinonjs/commons" "^3.0.0"
+
+"@theme-ui/css@^0.4.0-rc.1":
+  version "0.4.0-rc.13"
+  resolved "https://registry.yarnpkg.com/@theme-ui/css/-/css-0.4.0-rc.13.tgz#ffe585bebe4fc91fea2935bb6beb40f50c6a7cf0"
+  integrity sha512-YEO462Ia26T+i/6p/B4EJt/p3qJanPsSYpRP7MK4GchF/LbuHi0MS+zc4TpctIuIqpXgQR3w75b6xJZG1Oqn1Q==
+  dependencies:
+    csstype "^2.5.7"
 
 "@tootallnate/once@2":
   version "2.0.0"
@@ -3178,6 +3190,11 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
+csstype@^2.5.7:
+  version "2.6.21"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.21.tgz#2efb85b7cc55c80017c66a5ad7cbd931fda3a90e"
+  integrity sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==
+
 csstype@^3.0.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
@@ -3401,6 +3418,16 @@ dotenv@^16.4.5, dotenv@~16.4.5:
   version "16.4.7"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.7.tgz#0e20c5b82950140aa99be360a8a5f52335f53c26"
   integrity sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==
+
+dripsy@^4.3.8:
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/dripsy/-/dripsy-4.3.8.tgz#79fa23c77da9b29cdbe7fb9cbe49f3f23fe96779"
+  integrity sha512-ecgoixuYyzOA79PWDl0Xl3jfWr2ufMnnVWig0gDt4iCIozDIvV+gblq6hHH3pbtextLHxRyUdQulXLTjPW/Oaw==
+  dependencies:
+    "@expo/html-elements" "^0.2.0"
+    "@theme-ui/css" "^0.4.0-rc.1"
+    stable-hash "^0.0.2"
+    ts-toolbelt "^9.6.0"
 
 dunder-proto@^1.0.0:
   version "1.0.0"
@@ -7877,6 +7904,11 @@ ssri@^10.0.0:
   dependencies:
     minipass "^7.0.3"
 
+stable-hash@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stable-hash/-/stable-hash-0.0.2.tgz#a909deaa5b9d430b100ca0a10132a533f2665e94"
+  integrity sha512-tPwQ3c1rLIwbJpq59duoznegEbmgfV630C2n4R4G96LKBFljgK8j+O9AxjqB6cAzu4gE7s4pByrLWtZel8E+Mg==
+
 stable-hash@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/stable-hash/-/stable-hash-0.0.4.tgz#55ae7dadc13e4b3faed13601587cec41859b42f7"
@@ -8355,6 +8387,11 @@ ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
+
+ts-toolbelt@^9.6.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz#50a25426cfed500d4a09bd1b3afb6f28879edfd5"
+  integrity sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==
 
 tsconfig-paths@^3.15.0:
   version "3.15.0"


### PR DESCRIPTION
## In this PR
- Copy over README guidelines I've used on other projects for file organization. The main part of the README that is specific to _this_ repo is the first part under [Directories](https://github.com/prax-wallet/prax-mobile/pull/4/files#diff-a3fabeea7893828d3b393179dce2fd6dd0604a53f2aaa1ebbf03612b7fec15e5R13-R31), where I specify that we use the `app` directory only for routing, not for UI components.
- Extract a `<RootLayout />` component (which will eventually contain some actual UI).
- Extract app initialization to `<RootLayout />` (by way of the `useInitializeApp()` hook).
- Create an `AppInitializationContext`.
- Install [Dripsy](https://www.dripsy.xyz/) and use it to make our theme available.
- Copy over the theme file from web. Eventually we'll want to export the object from `@penumbra-zone/ui`, but for now, I'm just getting things up and running.